### PR TITLE
Allow specifying filename

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GenTeX"
 uuid = "986b9465-75d6-44a0-94a2-e5aa8586ae9d"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Generating LaTeX images is slow.
 Therefore, this project implements a in-memory cache which is also stored to disk.
 This is useful for speeding up local development and GitHub workflows.
 
+For most use-cases, I would advise [Franklin.jl](https://github.com/tlienart/Franklin.jl).
+
 ## Installation
 
 In the Julia REPL, GenTeX can be installed by hitting `]` to enter the Pkg mode:
@@ -23,27 +25,14 @@ In the Julia REPL, GenTeX can be installed by hitting `]` to enter the Pkg mode:
 ```
 julia> ]
 
-(v1.0) pkg> add GenTeX
+pkg> add GenTeX
 ```
 
 Alternatively, use 
 ```
-using Pkg 
-
+using Pkg
 Pkg.add("GenTeX")
 ```
-
-## Demo
-
-My blog uses this package.
-For example, see
-
-- https://huijzer.xyz/posts/correlations for some math or
-- https://huijzer.xyz/about-site/ for a TikZ picture.
-
-The source code is at <https://github.com/rikhuijzer/site>.
-
-For a simple example, see the [documentation](https://rikhuijzer.github.io/GenTeX.jl/dev/).
 
 ## Syntax
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
   Generate LaTeX images
 </h3>
 
+**This project is deprecated**, because the exact baseline of the SVG images was hard to determine causing the equations not to be aligned properly with the rest of the text and because adding LaTeX to a CI build will cause the build to be much longer.
+Also, cross-references were not supported yet.
+Alternatives:
+
+- for pre-rendering LaTeX without using LaTeX but with excellent output, see [Franklin.jl](https://github.com/tlienart/Franklin.jl)
+- for inserting Tikz, see [TikzPictures](https://github.com/JuliaTeX/TikzPictures.jl)
+
 This is a wrapper around `pdflatex`, `pdfcrop` and `dvisvgm` (to obtain SVG images) and is based on [latex-formulae](https://github.com/liamoc/latex-formulae).
 Benefits of rendering LaTeX to images are to
 
@@ -16,7 +23,7 @@ Generating LaTeX images is slow.
 Therefore, this project implements a in-memory cache which is also stored to disk.
 This is useful for speeding up local development and GitHub workflows.
 
-For most use-cases, I would advise [Franklin.jl](https://github.com/tlienart/Franklin.jl).
+For most use-cases, I would advise
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,7 @@
 # GenTeX.jl
 
-The most important function is `substitute_latex`.
+For most situations, I would advise to use [Franklin.jl](https://github.com/tlienart/Franklin.jl) which has great build in support for pre-rendering LaTeX equations.
+If you want to use real LaTeX, then the most important function is `substitute_latex`.
 
 ```@docs
 substitute_latex
@@ -22,8 +23,3 @@ md = substitute_latex(raw"$u$ and $v$", 1, tmpdir)
 rm(tmpdir, recursive=true)
 md
 ```
-
-## Full example
-
-For a more complete example with proper alignment and scaling, see <https://huijzer.xyz/posts/correlations>.
-The source code is available at <https://github.com/rikhuijzer/site>.

--- a/latex.nix
+++ b/latex.nix
@@ -2,7 +2,7 @@
 
 let
   # Pinning explicitly to 20.03.
-  rev = "5272327b81ed355bbed5659b8d303cf2979b6953";
+  rev = "cd63096d6d887d689543a0b97743d28995bc9bc3";
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
   pkgs = import nixpkgs {};
   myTex = with pkgs; texlive.combine {

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -8,6 +8,7 @@ struct Equation
 	scale::Float64
 	type::String # Either `display` or `inline`.
 	extra_packages::String # For example, \usepackage{tikz}.
+    filename::String # Output filename without extension.
 end
 
 struct DisplayImage
@@ -174,7 +175,7 @@ function latex_im(eq::Equation, im_dir::String)::Union{DisplayImage,InlineImage}
     end
     mv(file("crop"), file("svg"))
     tmpfilename = split(tmpdir, '/')[end-1]
-    im_name = "$(hash(eq.text)).svg"
+    im_name = eq.filename * ".svg"
     im_path = joinpath(im_dir, im_name)
     mv(file("svg"), im_path, force=true)
     cd(old_pwd)
@@ -235,7 +236,7 @@ end
 function eq_replace!(cache, eq::SubString, scale, im_dir, extra_packages)::String
     is_display = (startswith(eq, raw"$$") || startswith(eq, raw"\[") || startswith(eq, raw"\begin{eq")) 
     eq_type = is_display ? "display" : "inline"
-    _eq!(cache, Equation(eq, scale, eq_type, extra_packages), im_dir)
+    _eq!(cache, Equation(eq, scale, eq_type, extra_packages, string(hash(eq))), im_dir)
 end
 
 """

--- a/test/cache.jl
+++ b/test/cache.jl
@@ -9,14 +9,16 @@ DisplayImage = GenTeX.DisplayImage
 
 	scale = 1.0
 	cache = GenTeX.load_cache(scale, tmpdir)
-	eq = GenTeX.Equation(raw"$x$", scale, "inline", "")
+    text = raw"$x$"
+    hash_text = string(hash(text))
+	eq = GenTeX.Equation(text, scale, "inline", "", hash_text)
 	eq_image = DisplayImage(eq, tmpdir, "hash.svg")
 	@test GenTeX.check_cache(cache, eq) == nothing
 	GenTeX.update_cache!(cache, eq_image)
 	@test GenTeX.check_cache(cache, eq) == eq_image
-	eq2 = GenTeX.Equation(raw"$x$", scale, "display", "")
+	eq2 = GenTeX.Equation(text, scale, "display", "", hash_text)
 	@test GenTeX.check_cache(cache, eq2) == nothing
-	eq3 = GenTeX.Equation(raw"$x$", scale, "inline", "")
+	eq3 = GenTeX.Equation(text, scale, "inline", "", hash_text)
 	@test GenTeX.check_cache(cache, eq3) == eq_image
 	
 	GenTeX.write_cache!(cache, tmpdir)


### PR DESCRIPTION
Allow users to specify the output filename for the generated LaTeX SVGs instead of defaulting to a hash of the equation's text.